### PR TITLE
Fix language codes on 404 pages

### DIFF
--- a/docs/al/404.html
+++ b/docs/al/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/al/404.html
+++ b/docs/al/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="al">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/bg/404.html
+++ b/docs/bg/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/bg/404.html
+++ b/docs/bg/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="bg">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/bs/404.html
+++ b/docs/bs/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/bs/404.html
+++ b/docs/bs/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="bs">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/cs/404.html
+++ b/docs/cs/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/cs/404.html
+++ b/docs/cs/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="cs">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/da/404.html
+++ b/docs/da/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="da">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/da/404.html
+++ b/docs/da/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/de/404.html
+++ b/docs/de/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="de">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/de/404.html
+++ b/docs/de/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/ee/404.html
+++ b/docs/ee/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="ee">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/ee/404.html
+++ b/docs/ee/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/el/404.html
+++ b/docs/el/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="el">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/el/404.html
+++ b/docs/el/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/en/404.html
+++ b/docs/en/404.html
@@ -7,7 +7,7 @@
    Total Design Consulting
   </title>
   <link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-..." rel="stylesheet"/>
-  <link href="assets/css/custom.css" rel="stylesheet"/>
+  <link href="../assets/css/custom.css" rel="stylesheet"/>
  </head>
  <body>
   <div class="container-fluid px-0">

--- a/docs/es/404.html
+++ b/docs/es/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="es">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/es/404.html
+++ b/docs/es/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/et/404.html
+++ b/docs/et/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/et/404.html
+++ b/docs/et/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="et">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/fi/404.html
+++ b/docs/fi/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="fi">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/fi/404.html
+++ b/docs/fi/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/fr/404.html
+++ b/docs/fr/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/fr/404.html
+++ b/docs/fr/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="fr">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/hr/404.html
+++ b/docs/hr/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="hr">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/hr/404.html
+++ b/docs/hr/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/hu/404.html
+++ b/docs/hu/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="hu">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/hu/404.html
+++ b/docs/hu/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/is/404.html
+++ b/docs/is/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="is">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/is/404.html
+++ b/docs/is/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/it/404.html
+++ b/docs/it/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/it/404.html
+++ b/docs/it/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="it">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/lt/404.html
+++ b/docs/lt/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/lt/404.html
+++ b/docs/lt/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="lt">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/lv/404.html
+++ b/docs/lv/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/lv/404.html
+++ b/docs/lv/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="lv">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/mk/404.html
+++ b/docs/mk/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/mk/404.html
+++ b/docs/mk/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="mk">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/nl/404.html
+++ b/docs/nl/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="nl">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/nl/404.html
+++ b/docs/nl/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/no/404.html
+++ b/docs/no/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="no">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/no/404.html
+++ b/docs/no/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/pl/404.html
+++ b/docs/pl/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="pl">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/pl/404.html
+++ b/docs/pl/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/pt/404.html
+++ b/docs/pt/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/pt/404.html
+++ b/docs/pt/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="pt">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/ro/404.html
+++ b/docs/ro/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/ro/404.html
+++ b/docs/ro/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="ro">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/sk/404.html
+++ b/docs/sk/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/sk/404.html
+++ b/docs/sk/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="sk">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/sl/404.html
+++ b/docs/sl/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/sl/404.html
+++ b/docs/sl/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="sl">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/sq/404.html
+++ b/docs/sq/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="sq">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/sq/404.html
+++ b/docs/sq/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/sr/404.html
+++ b/docs/sr/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="sr">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/sr/404.html
+++ b/docs/sr/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/sv/404.html
+++ b/docs/sv/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="sv">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/sv/404.html
+++ b/docs/sv/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;

--- a/docs/tr/404.html
+++ b/docs/tr/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="tr">
 <head><meta content="Page not found. Return to Total Design Consulting homepage." name="description"/>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/docs/tr/404.html
+++ b/docs/tr/404.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="noindex" name="robots"/>
 <title>Page Not Found - Total Design Consulting</title>
-<link href="assets/css/style.css" rel="stylesheet"/>
+<link href="../assets/css/style.css" rel="stylesheet"/>
 <style>
   body {
     font-family: 'Segoe UI', Arial, sans-serif;


### PR DESCRIPTION
## Summary
- set the `lang` attribute on all localized 404 pages to the correct language code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c948a7948322b1cb27c1f927b1ce