### PR TITLE
Fix templates and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ This is the static marketing site for [Total Design Consulting LLC](https://www.
 - **Testimonials**: Card-based client feedback with icons/photos.
 - **Contact page**: Multiple contact methods (email, SMS, phone), with a pre-filled email template.
 - **404 page**: Friendly, branded error page.
-- **CSS**: All custom styles are in `assets/css/style.css` and used across all pages.
+- **CSS**: Core styles live in `assets/css/style.css`. Some pages also load `custom.css` for additional tweaks.
 - **Assets**: Place all images, CSS, and JS in the `assets/` folder.
-- **Accessibility**: Skip links are present but visually subtle (positioned off-screen until focused), semantic HTML, and accessible navigation.
+- **Accessibility**: A skip link is included on a few pages and styled to be visually subtle (positioned off-screen until focused). Semantic HTML and accessible navigation are used throughout.
 - **SEO**: Meta tags, Open Graph, and structured data included.
 - **Internationalization**: Language switcher for English and NATO languages (e.g. `/de/index.html`, `/es/index.html`, `/fr/index.html`, etc.). Ensure translated files exist as needed.
 - **Uniformity**: All pages (home, services, contact, testimonials, 404, and language variants) use the same header, navigation, language switcher (top right), footer, and CSS for a consistent look and feel.
@@ -63,3 +63,12 @@ All files in `docs/` are automatically served by GitHub Pages.
 - To add a favicon, place `favicon.ico` in `/docs/` and add the appropriate `<link rel="icon" ...>` tag to each HTML `<head>`.
 - All HTML pages are hand-coded for performance and maintainability.
 - For language support, copy and translate `index.html` to `/[lang]/index.html` for each supported NATO language.
+
+## Testing
+
+Install `pytest` and run the test suite from the repository root:
+
+```bash
+pip install pytest
+pytest
+```

--- a/docs/404.html
+++ b/docs/404.html
@@ -41,7 +41,7 @@
      </a>
     </nav>
    </header>
-   <main>
+  <main id="main">
     <section class="hero">
      <div class="hero-title">
       Secure. Automate. Deliver.

--- a/docs/assets/email-template.txt
+++ b/docs/assets/email-template.txt
@@ -2,7 +2,7 @@ Hello, Hola, Namaste, Guten Tag, Hallo, Salam, Hej!
 
 I am looking for some information from you and have some questions about [  ]
 
-I would like you reply to my questions by [  ] day and [  ] time.
+I would like you to reply to my questions by [  ] day and [  ] time.
 
 Contact me at [  ] 
 

--- a/docs/assets/sms-template.txt
+++ b/docs/assets/sms-template.txt
@@ -2,7 +2,7 @@ Hello, Hola, Namaste, Guten Tag, Hallo, Salam, Hej!
 
 I am looking for some information from you and have some questions about [  ]
 
-I would like you reply to my questions by [  ] day and [  ] time.
+I would like you to reply to my questions by [  ] day and [  ] time.
 
 Contact me at [  ] 
 

--- a/docs/icon-preview.html
+++ b/docs/icon-preview.html
@@ -41,7 +41,7 @@
      </a>
     </nav>
    </header>
-   <main>
+  <main id="main">
     <section class="hero">
      <div class="hero-title">
       Secure. Automate. Deliver.

--- a/docs/languages.html
+++ b/docs/languages.html
@@ -40,7 +40,8 @@
       Testimonials
      </a>
     </nav>
-   </header>
+  </header>
+  <main id="main">
    <h1>
     Select Your Language
    </h1>
@@ -176,6 +177,7 @@
      </a>
     </li>
    </ul>
+  </main>
    <footer>
     <p>
      © 2025 Total Design Consulting LLC |

--- a/tests/test_auto_translate.py
+++ b/tests/test_auto_translate.py
@@ -1,0 +1,62 @@
+import os
+from pathlib import Path
+import sys
+import types
+import re
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Provide a minimal stub for the openai package required by auto_translate_site
+sys.modules.setdefault("openai", types.SimpleNamespace(OpenAI=lambda api_key: None))
+
+class _Tag:
+    def __init__(self, name, string):
+        self.name = name
+        self.string = string
+
+class _SimpleSoup:
+    def __init__(self, html, parser="html.parser"):
+        self.tags = [
+            _Tag(m.group(1), m.group(2))
+            for m in re.finditer(r"<(\w+)>([^<]+)</\1>", html)
+        ]
+
+    def find_all(self, names):
+        return [t for t in self.tags if t.name in names]
+
+FakeBS4 = types.SimpleNamespace(BeautifulSoup=_SimpleSoup)
+sys.modules.setdefault("bs4", FakeBS4)
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
+
+import auto_translate_site as ats
+from bs4 import BeautifulSoup
+
+
+def test_extract_translatable_text():
+    html = "<h1>Hello</h1><p>World</p><div>Ignore</div>"
+    soup = BeautifulSoup(html, "html.parser")
+    tags = ats.extract_translatable_text(soup)
+    assert [t.name for t in tags] == ["h1", "p"]
+
+
+def test_ensure_all_files_present(tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    en = docs / "en"
+    es = docs / "es"
+    en.mkdir(parents=True)
+    es.mkdir(parents=True)
+
+    (en / "index.html").write_text("EN index")
+    (en / "services.html").write_text("EN services")
+    (es / "index.html").write_text("existing")
+
+    monkeypatch.setattr(ats, "BASE_DIR", docs)
+    monkeypatch.setattr(ats, "EN_DIR", en)
+    monkeypatch.setattr(ats, "LANG_CODES", ["es"])
+    monkeypatch.setattr(ats, "HTML_FILES", ["index.html", "services.html"])
+
+    ats.ensure_all_files_present()
+
+    assert (es / "services.html").read_text() == "EN services"
+    assert (es / "index.html").read_text() == "existing"
+


### PR DESCRIPTION
## Summary
- correct grammar in email & SMS templates
- hook up skip link targets in a few HTML pages
- document custom styles and testing instructions in README
- wrap language list in `<main id="main">`
- add starter pytest suite for `auto_translate_site`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c9488c0c8322b91c49912a24791a